### PR TITLE
Fix: Conditionally dequantize k and v in Attention layer

### DIFF
--- a/model/modeling_bart_multi_concat.py
+++ b/model/modeling_bart_multi_concat.py
@@ -812,8 +812,10 @@ class Attention(nn.Module):
             k = self.k_proj(query)
             v = self.v_proj(query)
 
-        k = self.dequant_k_proj(k)
-        v = self.dequant_v_proj(v)
+        if k is not None:
+            k = self.dequant_k_proj(k)
+        if v is not None:
+            v = self.dequant_v_proj(v)
 
         q = self._shape(q, tgt_len, bsz)
         if k is not None:


### PR DESCRIPTION
This change addresses an AttributeError where `dequantize` was called on a NoneType object. By making the dequantization of k and v conditional on them not being None, we prevent this immediate error.

This may lead to a subsequent assertion failure (`assert k is not None`) if k is indeed None, which would help pinpoint issues with `encoder_hidden_states` being None in certain execution paths (e.g., text_only mode).